### PR TITLE
Fix #28 okconfig.cfg->add examples_directory_local

### DIFF
--- a/okconfig/config.py
+++ b/okconfig/config.py
@@ -44,5 +44,6 @@ try:
             elif keyword == "destination_directory": destination_directory = value
             elif keyword == "install_nrpe_script": install_nrpe_script = value
             elif keyword == "nsclient_installfiles": nsclient_installfiles = value
+            elif keyword == "examples_directory_local": examples_directory_local = value
 except ImportError:
     raise


### PR DESCRIPTION
examples_directory_local wasn't read when parsing okconfig.cfg, this should fix that
