### PR TITLE
Update services.cfg

### DIFF
--- a/usr/share/okconfig/templates/linux/services.cfg
+++ b/usr/share/okconfig/templates/linux/services.cfg
@@ -135,9 +135,9 @@ define service {
 	check_command                 okc-check_nrpe!check_updates -t 120
         service_description     Security Updates
         register                0
-	check_interval		36000
-	retry_interval		36000
-	notification_interval	36000
+	check_interval		1440
+	retry_interval		1440
+	notification_interval	1440
 }
 
 # Edited by PyNag on Wed May 30 10:36:43 2012


### PR DESCRIPTION
25 days is not a sane default for security update checks
