### PR TITLE
Added okc-nagios-check_nagiostats service check to nagios template

### DIFF
--- a/usr/share/okconfig/examples/windows.cfg-example
+++ b/usr/share/okconfig/examples/windows.cfg-example
@@ -30,6 +30,7 @@ define service {
 # windows-check_uptime
 # Warns if device has recently been rebooted
 # __WARNING = warning threshold (default = 1h)
+# __CRITICAL = critical threshold (default = 0m)
 define service {
 	use			okc-windows-check_uptime
 	host_name		HOSTNAME
@@ -37,6 +38,7 @@ define service {
 
 	#service_description	Uptime
 	#__WARNING		1h
+	#__CRITICAL		0m
 }
 
 # windows-check_services

--- a/usr/share/okconfig/templates/nagios/commands.cfg
+++ b/usr/share/okconfig/templates/nagios/commands.cfg
@@ -2,3 +2,13 @@ define command {
 	command_name	okc-nagios-check_gearman
 	command_line	check_gearman -H $HOSTADDRESS$
 }
+
+define command {
+        command_name    okc-nagios-check_nagiostats
+        command_line    $USER1$/check_nagiostats
+}
+
+define command {
+        command_name    okc-nagios-check_nagiostats_passive
+        command_line    $USER1$/check_dummy $ARG1$ $ARG2$
+}

--- a/usr/share/okconfig/templates/nagios/services.cfg
+++ b/usr/share/okconfig/templates/nagios/services.cfg
@@ -33,3 +33,21 @@ define service {
 	check_command		okc-nagios-check_gearman
 	register		0
 }
+
+define service {
+        use                     generic-service
+        name                    okc-nagios-check_nagiostats
+        service_description     Nagios Statistics
+        check_command           okc-nagios-check_nagiostats
+        register                0
+}
+
+define service {
+        use                     generic-service
+        name                    okc-nagios-check_nagiostats_passive
+        service_description     Nagios Statistics Passive
+        check_command           okc-nagios-check_nagiostats_passive!3!Freshness threshold exceeded
+        check_freshness         1
+        freshness_threshold     180    #check interval + x seconds
+        register                0
+}

--- a/usr/share/okconfig/templates/windows/commands.cfg
+++ b/usr/share/okconfig/templates/windows/commands.cfg
@@ -28,7 +28,7 @@ define command {
 # Edited by PyNag on Wed May 30 10:18:44 2012
 define command {
 	command_name                  okc-windows-check_uptime
-  command_line	$USER1$/check_nrpe -H $HOSTADDRESS$ -c CheckUptime -a MinWarn=$ARG1$
+  command_line	$USER1$/check_nrpe -H $HOSTADDRESS$ -c CheckUptime -a MinWarn=$ARG1$ MinCrit=$ARG2$
 }
 
 # windows-show_net

--- a/usr/share/okconfig/templates/windows/services.cfg
+++ b/usr/share/okconfig/templates/windows/services.cfg
@@ -47,8 +47,9 @@ define service {
 	use                           okc-windows-service
 	name                          okc-windows-check_uptime
 	__WARNING		1h
+	__CRITICAL		0m
 	
-	check_command                 okc-windows-check_uptime!$_SERVICE_WARNING$
+	check_command                 okc-windows-check_uptime!$_SERVICE_WARNING$!$_SERVICE_CRITICAL$
 	service_description	Uptime
 	register		0
 	notifications_enabled	0


### PR DESCRIPTION
# Plugin information
This check uses check_nagiostats plugin written by [Jochern Bern](https://www.monitoringexchange.org/inventory/Check-Plugins/Software/Nagios/check_nagiostats)

# Installation

The plugin is available here https://www.monitoringexchange.org/attachment/download/Check-Plugins/Software/Nagios/check_nagiostats/check_nagiostats

## PNP4Nagios setup

Create a symbolic link for pnp4nagios template nagiostats.php so it can be applied to okc-nagios-check_nagiostats

```
sudo ln -s /usr/share/nagios/html/pnp4nagios/templates.dist/nagiostats.php /usr/share/nagios/html/pnp4nagios/templates.dist/okc-nagios-check_nagiostats.php
sudo ln -s /usr/share/nagios/html/pnp4nagios/templates.dist/nagiostats.php /usr/share/nagios/html/pnp4nagios/templates.dist/okc-nagios-check_nagiostats_passive.php
```

![performance information - mozilla firefox_2013-10-29_11-03-16](https://f.cloud.github.com/assets/3597603/1427425/e431d394-4089-11e3-947e-5f4ec5702cbc.jpg)
![hoststat](https://f.cloud.github.com/assets/3597603/1427468/0689dc10-408b-11e3-8584-9c697f4154c5.jpg)
![execution](https://f.cloud.github.com/assets/3597603/1427469/06bd276e-408b-11e3-9686-3f502c8e7ce4.jpg)
![check_latency](https://f.cloud.github.com/assets/3597603/1427470/06c15dc0-408b-11e3-88ae-35b772dc662a.jpg)

# Nagios config information

These configs are based on [this](http://docs.icinga.org/latest/en/perfgraphs.html)

There are two services defined for okc-nagios-check_nagiostats
+ Active Check - okc-nagios-check_nagiostats
+ Passive Check - okc-nagios-check_nagiostats_passive

With passive check you are able to get regular intervals and more control over the resolution into your graphs.
To run the check in passive mode, make something like this in crontab of nagios user:

```
* * * * * /usr/lib64/nagios/plugins/check_nagiostats --passive "nagios.example.com" "Nagios Statistics Passive" >> /var/spool/nagios/cmd/nagios.cmd
```


