### PR TITLE
fix line continuation bug in service config

### DIFF
--- a/usr/share/okconfig/templates/misc/services.cfg
+++ b/usr/share/okconfig/templates/misc/services.cfg
@@ -5,7 +5,7 @@ define service {
     __FILTER_TYPE		in
     __FILE_SIZE            	>0M
     __FILE_MODIFIED     	>0s
-    __PATH                        c:\program files\
+    __PATH                        c:\program files
     __PATTERN                 	*.*
     __OUTPUT                   	%matches% out of %files% files match filter expression
     __MAX_DIR_DEPTH           	0


### PR DESCRIPTION
The trailing backslash makes pynag return the __PATH macro as `c:\program files\        __PATTERN                   *.*` 
