### PR TITLE
Update commands.cfg

### DIFF
--- a/usr/share/okconfig/templates/cisco/commands.cfg
+++ b/usr/share/okconfig/templates/cisco/commands.cfg
@@ -50,7 +50,7 @@ define command {
 # Edited by PyNag on Wed May 30 10:19:07 2012
 define command {
 	command_name                  okc-cisco-check_snmp_interfaces
-        command_line            $USER1$/check_snmp_interfaces -H $HOSTADDRESS$ -C $ARG1$ -v $ARG2$
+        command_line            $USER1$/check_snmp_interfaces -H $HOSTADDRESS$ -C $ARG1$ -E $ARG2$
 }
 
 


### PR DESCRIPTION
the "check_snmp_interfaces" does not have a -v option, instead, it is -E
