### PR TITLE
Update keyword argument for host deletion to match what pynag expects

### DIFF
--- a/okconfig/__init__.py
+++ b/okconfig/__init__.py
@@ -375,7 +375,7 @@ def removehost(host_name, recursive=True):
     >>> removehost('host.example.com', recursive=True) # doctest: +SKIP
     """
     my_host = pynag.Model.Host.objects.get_by_shortname(host_name)
-    my_host.delete(cascade=recursive)
+    my_host.delete(recursive=recursive)
     return True
 
 def get_templates():


### PR DESCRIPTION
Pynag changed the keyword for recursive deletion a couple version back, this breaks trying to delete a host via okconfig. Changing the keyword passed from okconfig fixes it.
