### PR TITLE
Add missing names to templates

### DIFF
--- a/usr/share/okconfig/templates/exchange/services-statistics.cfg
+++ b/usr/share/okconfig/templates/exchange/services-statistics.cfg
@@ -73,6 +73,7 @@ define service{
 # Edited by PyNag on Wed May 30 10:37:01 2012
 define service{
 	use                           okc-exchange-service
+	name				okc-exchange-msg-sent-tot
 	service_description	Microsoft Exchange Messages Sent Total
 	check_command                 okc-exc-msg-sent-tot
 	 register                       0
@@ -80,6 +81,7 @@ define service{
 # Edited by PyNag on Wed May 30 10:37:01 2012
 define service{
 	use                           okc-exchange-service
+	name				okc-exchange-msg-sub-tot
 	service_description	Microsoft Exchange Messages Submitted Total
 	check_command                 okc-exc-msg-sub-tot
 	 register                       0
@@ -87,6 +89,7 @@ define service{
 # Edited by PyNag on Wed May 30 10:37:02 2012
 define service{
 	use                           okc-exchange-service
+	name				okc-exchange-byte-sent-tot
 	service_description	Microsoft Exchange Bytes Sent Total  
 	check_command                 okc-exc-byte-sent-tot
 	 register                       0
@@ -94,6 +97,7 @@ define service{
 # Edited by PyNag on Wed May 30 10:37:02 2012
 define service{
 	use                           okc-exchange-service
+	name				okc-exchange-byte-recv-tot
 	service_description	Microsoft Exchange Bytes Received Total
 	check_command                 okc-exc-byte-recv-tot
 	 register                       0
@@ -101,6 +105,7 @@ define service{
 # Edited by PyNag on Wed May 30 10:37:03 2012
 define service{
 	use                           okc-exchange-service
+	name				okc-exchange-scl0
 	service_description	Microsoft Exchange Content Filter Agent Messages with SCL0
 	check_command                 okc-exc-scl0
 	 register                       0
@@ -108,6 +113,7 @@ define service{
 # Edited by PyNag on Wed May 30 10:37:03 2012
 define service{
 	use                           okc-exchange-service
+	name				okc-exchange-scl1
 	service_description	Microsoft Exchange Content Filter Agent Messages with SCL1       
 	check_command                 okc-exc-scl1
 	 register                       0
@@ -115,6 +121,7 @@ define service{
 # Edited by PyNag on Wed May 30 10:37:03 2012
 define service{
 	use                           okc-exchange-service
+	name				okc-exchange-scl2
 	service_description	Microsoft Exchange Content Filter Agent Messages with SCL2
 	check_command                 okc-exc-scl2
 	 register                       0
@@ -122,6 +129,7 @@ define service{
 # Edited by PyNag on Wed May 30 10:37:04 2012
 define service{
 	use                           okc-exchange-service
+	name				okc-exchange-scl3
 	service_description	Microsoft Exchange Content Filter Agent Messages with SCL3
 	check_command                 okc-exc-scl3
 	 register                       0
@@ -129,6 +137,7 @@ define service{
 # Edited by PyNag on Wed May 30 10:37:04 2012
 define service{
 	use                           okc-exchange-service
+	name				okc-exchange-scl4
 	service_description	Microsoft Exchange Content Filter Agent Messages with SCL4
 	check_command                 okc-exc-scl4
 	 register                       0
@@ -136,6 +145,7 @@ define service{
 # Edited by PyNag on Wed May 30 10:37:04 2012
 define service{
 	use                           okc-exchange-service
+	name				okc-exchange-scl5
 	service_description	Microsoft Exchange Content Filter Agent Messages with SCL5
 	check_command                 okc-exc-scl5
 	 register                       0
@@ -144,6 +154,7 @@ define service{
 # Edited by PyNag on Wed May 30 10:37:05 2012
 define service{
 	use                           okc-exchange-service
+	name				okc-exchange-scl6
 	service_description	Microsoft Exchange Content Filter Agent Messages with SCL6
 	check_command                 okc-exc-scl6
 	 register                       0
@@ -151,6 +162,7 @@ define service{
 # Edited by PyNag on Wed May 30 10:37:05 2012
 define service{
 	use                           okc-exchange-service
+	name				okc-exchange-scl7
 	service_description	Microsoft Exchange Content Filter Agent Messages with SCL7
 	check_command                 okc-exc-scl7
 	 register                       0
@@ -158,6 +170,7 @@ define service{
 # Edited by PyNag on Wed May 30 10:37:06 2012
 define service{
 	use                           okc-exchange-service
+	name				okc-exchange-scl8
 	service_description	Microsoft Exchange Content Filter Agent Messages with SCL8
 	check_command                 okc-exc-scl8
 	 register                       0
@@ -166,8 +179,9 @@ define service{
 # Edited by PyNag on Wed May 30 10:37:06 2012
 define service{
 	use                           okc-exchange-service
+	name				okc-exchange-scl9
 	service_description	Microsoft Exchange Content Filter Agent Messages with SCL9
-	check_command                 okc-exc-scl8
+	check_command                 okc-exc-scl9
 	 register                       0
 }
 
@@ -175,6 +189,7 @@ define service{
 # Edited by PyNag on Wed May 30 10:37:06 2012
 define service{
 	use                           okc-exchange-service
+	name				okc-exchange-msg-scan
 	service_description	Microsoft Exchange Messages Scanned
 	check_command                 okc-exc-msg-scan
 	 register                       0
@@ -182,6 +197,7 @@ define service{
 # Edited by PyNag on Wed May 30 10:37:07 2012
 define service{
 	use                           okc-exchange-service
+	name				okc-exchange-msg-bypass
 	service_description	Microsoft Exchange Messages Bypassed
 	check_command                 okc-exc-msg-bypass
 	 register                       0
@@ -189,6 +205,7 @@ define service{
 # Edited by PyNag on Wed May 30 10:37:07 2012
 define service{
 	use                           okc-exchange-service
+	name				okc-exchange-msg-del
 	service_description	Microsoft Exchange Messages Deleted
 	check_command                 okc-exc-msg-del
 	 register                       0
@@ -196,6 +213,7 @@ define service{
 # Edited by PyNag on Wed May 30 10:37:08 2012
 define service{
 	use                           okc-exchange-service
+	name				okc-exchange-msg-rej
 	service_description	Microsoft Exchange Messages Rejected
 	check_command                 okc-exc-msg-rej
 	 register                       0
@@ -203,6 +221,7 @@ define service{
 # Edited by PyNag on Wed May 30 10:37:08 2012
 define service{
 	use                           okc-exchange-service
+	name				okc-exchange-msg-quar
 	service_description	Microsoft Exchange Messages Quarantined
 	check_command                 okc-exc-msg-quar
 	 register                       0
@@ -210,6 +229,7 @@ define service{
 # Edited by PyNag on Wed May 30 10:37:08 2012
 define service{
 	use                           okc-exchange-service
+	name				okc-exchange-msg-unkn
 	service_description	Microsoft Exchange Messages Unknown
 	check_command                 okc-exc-msg-unkn
 	 register                       0
@@ -217,6 +237,7 @@ define service{
 # Edited by PyNag on Wed May 30 10:37:09 2012
 define service{
 	use                           okc-exchange-service
+	name				okc-exchange-msg-user
 	service_description	Microsoft Exchange User Count
 	check_command                 okc-exc-msg-user
 	 register                       0
@@ -224,6 +245,7 @@ define service{
 # Edited by PyNag on Wed May 30 10:37:09 2012
 define service{
 	use                           okc-exchange-service
+	name				okc-exchange-msg-active-user
 	service_description	Microsoft Exchange Active Users
 	check_command                 okc-exc-msg-active-user
 	 register                       0
@@ -232,6 +254,7 @@ define service{
 # Edited by PyNag on Wed May 30 10:37:10 2012
 define service{
 	use                           okc-exchange-service
+	name				okc-exchange-msg-unique-usr
 	service_description	Microsoft Exchange Unique OWA Users
 	check_command                 okc-exc-msg-unique-usr
 	 register                       0


### PR DESCRIPTION
The service templates specified are "unreachable" since there is no name on them.
