### PR TITLE
Upped default check_interval for hosts from 1 to 5

### DIFF
--- a/usr/share/okconfig/templates/misc/hosts.cfg
+++ b/usr/share/okconfig/templates/misc/hosts.cfg
@@ -4,7 +4,7 @@ define host {
 	name				okc-default-host
 	use				generic-host
 	max_check_attempts		10
-        check_interval                  1               
+        check_interval                  5
         retry_interval                  2               
         max_check_attempts              3              
         check_command                   check-host-alive 


### PR DESCRIPTION
This is creating load and I don't think 1 is a sane default.
