### PR TITLE
Add listhost command

### DIFF
--- a/usr/bin/okconfig
+++ b/usr/bin/okconfig
@@ -250,19 +250,21 @@ Run %prog listhost --help for full list of command line arguments.
     if not opts.host:
         if len(args) > 0:
             opts.host = args[0]
-    else:
-        parser.error("Please specify both host. See --help")
+        else:
+            parser.error("Please specify both host. See --help")
 
     import pynag.Model
-    host = pynag.Model.Host.objects.get_by_shortname(opts.host)
-    if host:
+    try:
+        host = pynag.Model.Host.objects.get_by_shortname(opts.host)
         header = "%-40s%s" % ('attribute', 'value')
         print header
         print "-" * len(header)
         for key in host.keys():
+            if key in ['id', 'meta']:
+                continue
             print "%-40s%s" % (key, host.get_attribute(key))
         print "-" * len(header)
-    else:
+    except KeyError:
         print "Host not found."
 
 


### PR DESCRIPTION
I'm missing an okconfig command line operation to check if a host is defined. I'm trying to confine myself to okconfig and not go directly via pynag. Does this make sense? This is kind of wingin' it, any input appreciated.

I did literally no testing on this, it might not even parse, as I don't have a proper test setup for okconfig. I know, my bad. But the tests here do not seem to be self contained, it looks like they pollute the host system. Am I misreading it?
