### PR TITLE
Removed crit2warn from okc-windows-check_service

### DIFF
--- a/usr/share/okconfig/templates/windows/services.cfg
+++ b/usr/share/okconfig/templates/windows/services.cfg
@@ -75,7 +75,7 @@ define service {
 	name                          okc-windows-check_service
         __SERVICE		TSM Scheduler
 
-	check_command                 okc-crit2warn!$USER1$/check_nrpe -H $HOSTADDRESS$ -c CheckServiceState -a ShowAll  "$_SERVICE_SERVICE$"
+	check_command                 okc-check_nrpe!CheckServiceState -a ShowAll  "$_SERVICE_SERVICE$"
         service_description     Windows Service
         action_url
         register                0


### PR DESCRIPTION
Changed crit2warn to check_nrpe.
