### PR TITLE
Excluded RemoteRegistry

### DIFF
--- a/usr/share/okconfig/templates/windows/services.cfg
+++ b/usr/share/okconfig/templates/windows/services.cfg
@@ -59,8 +59,7 @@ define service {
 define service {
 	use                           okc-windows-service
 	name                          okc-windows-check_services
-	__EXTRAOPTS		exclude=TBS exclude=ShellHWDetection exclude=clr_optimization_v4.0.30319_32 exclude=clr_optimization_v4.0.30319_64 exclude=sppsvc exclude=spupdsvc exclude=MMCSS exclude=gupdate exclude=gupdatem	
-
+	__EXTRAOPTS		exclude=TBS exclude=ShellHWDetection exclude=clr_optimization_v4.0.30319_32 exclude=clr_optimization_v4.0.30319_64 exclude=sppsvc exclude=spupdsvc exclude=MMCSS exclude=gupdate exclude=gupdatem exclude=RemoteRegistry
 	check_command                 okc-crit2warn!$USER1$/check_nrpe -H $HOSTADDRESS$ -c CheckServiceState -a CheckAll exclude=wscsvc exclude=SysmonLog  exclude=clr_optimization_v4.0.30319_32 $_SERVICE_EXTRAOPTS$
 	service_description	Running Services
 	action_url


### PR DESCRIPTION
RemoteRegistry service starts and then shuts down if not being used. Normal behavior in Windows Server 2012.
