### PR TITLE
Fix DNS checks for compatibility with new version of check_dns plugin

### DIFF
--- a/usr/share/okconfig/templates/misc/autodiscover/commands.cfg
+++ b/usr/share/okconfig/templates/misc/autodiscover/commands.cfg
@@ -2,7 +2,7 @@
 # Edited by PyNag on Wed May 30 10:19:20 2012
 define command {
 	command_name                  okc-check_dns
-	command_line		$USER1$/check_dns -H $ARG1$ -a $ARG2$
+	command_line		$USER1$/check_dns -H $ARG1$ -a $ARG2$ -q $ARG3$
 }
 
 

--- a/usr/share/okconfig/templates/misc/autodiscover/services.cfg
+++ b/usr/share/okconfig/templates/misc/autodiscover/services.cfg
@@ -3,7 +3,7 @@ define service {
         use                     generic-service
 	name                          okc-check_reverse_lookup
         service_description     Forward Lookup
-	check_command                 okc-check_dns!$HOSTNAME$!$HOSTADDRESS$
+	check_command                 okc-check_dns!$HOSTNAME$!$HOSTADDRESS$!A
 	 register                       0
 }
 # Edited by PyNag on Wed May 30 14:06:33 2012
@@ -11,7 +11,7 @@ define service {
         use                     generic-service
 	name                          okc-check_forward_lookup
         service_description     Reverse Lookup
-	check_command                 okc-check_dns!$HOSTADDRESS$!$HOSTNAME$.
+	check_command                 okc-check_dns!$HOSTADDRESS$!$HOSTNAME$.!PTR
 	 register                       0
 }
 


### PR DESCRIPTION
This issue: https://github.com/nagios-plugins/nagios-plugins/issues/223 is not properly fix unless the -q parameter is passed to check_dns.

Works with nagios-plugins-dns-2.0.3-3.el6 as well as nagios-plugins-dns-2.2.1-4git.el6.